### PR TITLE
Add QMatrix to QtGui members

### DIFF
--- a/Qt.py
+++ b/Qt.py
@@ -253,6 +253,7 @@ _common_members = {
         "QKeyEvent",
         "QKeySequence",
         "QLinearGradient",
+        "QMatrix",
         "QMatrix2x2",
         "QMatrix2x3",
         "QMatrix2x4",

--- a/Qt.py
+++ b/Qt.py
@@ -44,7 +44,7 @@ import shutil
 import importlib
 
 
-__version__ = "1.2.2"
+__version__ = "1.2.3"
 
 # Enable support for `from Qt import *`
 __all__ = []

--- a/Qt.py
+++ b/Qt.py
@@ -253,7 +253,6 @@ _common_members = {
         "QKeyEvent",
         "QKeySequence",
         "QLinearGradient",
-        "QMatrix",
         "QMatrix2x2",
         "QMatrix2x3",
         "QMatrix2x4",

--- a/Qt.py
+++ b/Qt.py
@@ -683,7 +683,7 @@ _common_members = {
 
 This mapping describes members that have been deprecated
 in one or more bindings and have been left out of the
-_common_members mapping. 
+_common_members mapping.
 
 The member can provide an extra details string to be
 included in exceptions and warnings.

--- a/tests.py
+++ b/tests.py
@@ -792,6 +792,29 @@ def test_membership():
     )
 
 
+def test_missing():
+    """Missing members of Qt.py have been defined with placeholders"""
+    import Qt
+
+    missing_members = Qt._missing_members.copy()
+
+    missing = list()
+    for module, members in missing_members.items():
+
+        mod = getattr(Qt, module)
+        missing.extend(
+            member for member in members
+            if not hasattr(mod, member) or
+            not isinstance(getattr(mod, member), Qt.MissingMember)
+        )
+
+    binding = Qt.__binding__
+    assert not missing, (
+        "Some members did not exist in {binding} as "
+        "a Qt.MissingMember type\n{missing}".format(**locals())
+    )
+
+
 if sys.version_info <= (3, 4):
     # PySide is not available for Python > 3.4
     # Shiboken(1) doesn't support Python 3.5


### PR DESCRIPTION
Adds the missing `QtGui.QMatrix` member which should be present across all Qt4/5 bindings